### PR TITLE
Replaced paras with tokenize in describe method

### DIFF
--- a/snippets/ch03/reader.py
+++ b/snippets/ch03/reader.py
@@ -148,7 +148,7 @@ class HTMLCorpusReader(CategorizedCorpusReader, CorpusReader):
         tokens  = nltk.FreqDist()
 
         # Perform single pass over paragraphs, tokenize and count
-        for para in self.paras(fileids, categories):
+        for para in self.tokenize(fileids, categories):
             counts['paras'] += 1
 
             for sent in para:


### PR DESCRIPTION
self.paras() just returns paragraphs but we need tokenized words for the last for loop in self.describe(). In addition, paras does not seem to get the sentences right and I am not sure it should but this could just be my lack of understanding of the code. 